### PR TITLE
Fix progress bar form submit and tidy line width setting

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,7 +48,7 @@ def clean_text(text):
     text = emoji_pattern.sub(r'', text)
     return text.replace("\ufeff", "").replace("\u200b", "").strip()
 
-def format_line(line, width=42):
+def format_line(line, width=LINE_WIDTH):
     return "\n".join(textwrap.wrap(line, width=width))
 
 def detect_language(input_path):

--- a/templates/index.html
+++ b/templates/index.html
@@ -89,7 +89,7 @@
 <body>
   <div class="container">
     <img src="{{ url_for('static', filename='by_Anitec_Copia.png') }}" alt="AutoSRT Logo" class="logo">
-    <form method="POST" action="/tradutor" enctype="multipart/form-data" onsubmit="startProgress()">
+    <form method="POST" action="/tradutor" enctype="multipart/form-data">
       <input type="file" name="srt_file" required>
       <button type="submit">Traduzir</button>
     </form>


### PR DESCRIPTION
## Summary
- avoid duplicate progress initialization on form submit
- hook format_line to LINE_WIDTH constant

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684056f25a348330b86895b10cee4f9d