### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,7 @@
 <html lang="pt-br">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>AutoSRT - Tradutor de Legendas</title>
   <link rel="icon" href="{{ url_for('static', filename='icon.ico') }}" type="image/x-icon">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap" rel="stylesheet">
@@ -9,7 +10,7 @@
     body {
       margin: 0;
       font-family: 'Inter', sans-serif;
-      background-color: #1e1e1e;
+      background: linear-gradient(180deg, #1e1e1e 0%, #121212 100%);
       color: #ffffff;
       display: flex;
       flex-direction: column;
@@ -39,6 +40,7 @@
       border: 2px solid #444;
       border-radius: 9px;
       font-size: medium;
+      width: 100%;
     }
 
     button {
@@ -78,11 +80,29 @@
       margin-bottom: 25px;
     
     }
-    .message {
+.message {
       margin-top: 20px;
       color: #66ff99;
       font-weight: bold;
       font-size: 16px;
+    }
+
+    @media (max-width: 500px) {
+      .container {
+        padding: 20px;
+        width: 100%;
+      }
+      input[type="file"] {
+        padding: 20px;
+        font-size: 14px;
+      }
+      button {
+        padding: 12px 32px;
+        font-size: 18px;
+      }
+      .logo {
+        width: 60%;
+      }
     }
   </style>
 </head>

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -2,6 +2,7 @@
 <html lang="pt-br">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Bem-vindo ao AutoSRT</title>
   <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@500;700&display=swap" rel="stylesheet">
@@ -14,7 +15,7 @@
       margin: 0;
       padding: 0;
       font-family: 'Inter', sans-serif;
-      background: #16191b;
+      background: linear-gradient(180deg, #16191b 0%, #0f1011 100%);
       color: white;
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
## Summary
- add viewport meta tag for mobile device scaling
- tweak layout and fonts for mobile via CSS media queries
- update backgrounds with subtle gradients for a nicer look

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420a4ed38c8330a17ae31be1de51df