### PR TITLE
Fix logo name on main screen

### DIFF
--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -94,7 +94,7 @@
 </head>
 <body>
 
-  <img src="{{ url_for('static', filename='by_Anitec.png') }}" alt="AutoSRT Logo" class="logo">
+  <img src="{{ url_for('static', filename='by_Anitec_Copia.png') }}" alt="AutoSRT Logo" class="logo">
   <h2>Tradução Automática de Legendas .srt – Versão Web</h2>
 
   <a class="btn" href="{{ url_for('index') }}">▶ Começar</a>


### PR DESCRIPTION
## Summary
- use the same `by_Anitec_Copia.png` logo on both screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844587750b48330933bef4a51365af4