### PR TITLE
Use same logo on translator screen

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -108,7 +108,7 @@
 </head>
 <body>
   <div class="container">
-    <img src="{{ url_for('static', filename='by_Anitec_Copia.png') }}" alt="AutoSRT Logo" class="logo">
+    <img src="{{ url_for('static', filename='by_Anitec.png') }}" alt="AutoSRT Logo" class="logo">
     <form method="POST" action="/tradutor" enctype="multipart/form-data">
       <input type="file" name="srt_file" required>
       <button type="submit">Traduzir</button>

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -94,7 +94,7 @@
 </head>
 <body>
 
-  <img src="{{ url_for('static', filename='by_Anitec.png') }}" alt="AutoSRT Logo" class="logo">
+  <img src="{{ url_for('static', filename='by_Anitec_Copia.png') }}" alt="AutoSRT Logo" class="logo">
   <h2>Tradução Automática de Legendas .srt – Versão Web</h2>
 
   <a class="btn" href="{{ url_for('index') }}">▶ Começar</a>


### PR DESCRIPTION
## Summary
- ensure translator page uses `by_Anitec.png` like the welcome page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844587750b48330933bef4a51365af4